### PR TITLE
server: Add the endpoint to get the tpos contract encoded.

### DIFF
--- a/server/.sbtopts
+++ b/server/.sbtopts
@@ -1,0 +1,3 @@
+-J-Xmx4G
+-J-XX:MaxMetaspaceSize=4G
+-J-XX:+CMSClassUnloadingEnabled

--- a/server/app/com/xsn/explorer/models/request/TposContractsEncodeRequest.scala
+++ b/server/app/com/xsn/explorer/models/request/TposContractsEncodeRequest.scala
@@ -1,0 +1,15 @@
+package com.xsn.explorer.models.request
+
+import com.xsn.explorer.models.values.Address
+import play.api.libs.json._
+
+case class TposContractsEncodeRequest(
+    tposAddress: Address,
+    merchantAddress: Address,
+    commission: Int,
+    signature: String
+)
+
+object TposContractsEncodeRequest {
+  implicit val reads: Reads[TposContractsEncodeRequest] = Json.reads[TposContractsEncodeRequest]
+}

--- a/server/app/controllers/TransactionsController.scala
+++ b/server/app/controllers/TransactionsController.scala
@@ -1,7 +1,7 @@
 package controllers
 
 import com.alexitc.playsonify.core.FutureOr.Implicits.FutureOps
-import com.xsn.explorer.models.request.SendRawTransactionRequest
+import com.xsn.explorer.models.request.{SendRawTransactionRequest, TposContractsEncodeRequest}
 import com.xsn.explorer.services.TransactionRPCService
 import com.xsn.explorer.services.TransactionService
 import com.alexitc.playsonify.models.pagination.Limit
@@ -9,8 +9,11 @@ import controllers.common.{MyJsonController, MyJsonControllerComponents}
 import javax.inject.Inject
 import play.api.libs.json.Json
 
-class TransactionsController @Inject()(transactionRPCService: TransactionRPCService, transactionService: TransactionService, cc: MyJsonControllerComponents)
-    extends MyJsonController(cc) {
+class TransactionsController @Inject()(
+    transactionRPCService: TransactionRPCService,
+    transactionService: TransactionService,
+    cc: MyJsonControllerComponents
+) extends MyJsonController(cc) {
 
   import Context._
 
@@ -74,6 +77,22 @@ class TransactionsController @Inject()(transactionRPCService: TransactionRPCServ
       .map { value =>
         val response = Ok(Json.toJson(value))
         response.withHeaders("Cache-Control" -> "public, max-age=60")
+      }
+      .toFuture
+  }
+
+  def encodeTPOSContract() = publicInput { ctx: HasModel[TposContractsEncodeRequest] =>
+    transactionRPCService
+      .encodeTPOSContract(
+        tposAddress = ctx.model.tposAddress,
+        merchantAddress = ctx.model.merchantAddress,
+        commission = ctx.model.commission,
+        signature = ctx.model.signature
+      )
+      .toFutureOr
+      .map { value =>
+        val response = Ok(value)
+        response.withHeaders("Cache-Control" -> "no-store")
       }
       .toFuture
   }

--- a/server/conf/routes
+++ b/server/conf/routes
@@ -12,6 +12,7 @@ GET   /transactions/:txid/raw    controllers.TransactionsController.getRawTransa
 POST  /transactions              controllers.TransactionsController.sendRawTransaction()
 GET   /transactions/:txid/lite   controllers.TransactionsController.getTransactionLite(txid: String)
 GET   /transactions/:txid/utxos/:index               controllers.TransactionsController.getTransactionUtxoByIndex(txid: String, index: Int, includeMempool: Boolean ?= true)
+POST   /tposcontracts/encode     controllers.TransactionsController.encodeTPOSContract()
 
 GET   /addresses/:address                            controllers.AddressesController.getBy(address: String)
 GET   /addresses/:address/tposcontracts              controllers.AddressesController.getTPoSContracts(address: String)

--- a/server/test/com/xsn/explorer/helpers/DummyXSNService.scala
+++ b/server/test/com/xsn/explorer/helpers/DummyXSNService.scala
@@ -33,4 +33,13 @@ class DummyXSNService extends XSNService {
   override def getFullRawBlock(blockhash: Blockhash): FutureApplicationResult[JsValue] = ???
 
   override def getHexEncodedBlock(blockhash: Blockhash): FutureApplicationResult[String] = ???
+
+  override def encodeTPOSContract(
+      tposAddress: Address,
+      merchantAddress: Address,
+      commission: Int,
+      signature: String
+  ): FutureApplicationResult[String] = ???
+
+  override def getTPoSContractDetails(transactionId: TransactionId): FutureApplicationResult[TPoSContract.Details] = ???
 }

--- a/server/test/com/xsn/explorer/helpers/FileBasedXSNService.scala
+++ b/server/test/com/xsn/explorer/helpers/FileBasedXSNService.scala
@@ -2,8 +2,10 @@ package com.xsn.explorer.helpers
 
 import com.alexitc.playsonify.core.FutureApplicationResult
 import com.xsn.explorer.errors.{BlockNotFoundError, TransactionError}
+import com.xsn.explorer.helpers.DataGenerator.randomTPoSContract
+import com.xsn.explorer.models.TPoSContract
 import com.xsn.explorer.models.rpc.{Block, Transaction, TransactionVIN}
-import com.xsn.explorer.models.values.{Blockhash, Height, TransactionId}
+import com.xsn.explorer.models.values.{Address, Blockhash, Height, TransactionId}
 import org.scalactic.{Good, One, Or}
 import play.api.libs.json.JsValue
 
@@ -69,4 +71,20 @@ class FileBasedXSNService extends DummyXSNService {
   }
 
   override def isTPoSContract(txid: TransactionId): FutureApplicationResult[Boolean] = Future.successful(Good(true))
+
+  override def encodeTPOSContract(
+      tposAddress: Address,
+      merchantAddress: Address,
+      commission: Int,
+      signature: String
+  ): FutureApplicationResult[String] = {
+    val tposEncoded =
+      "020000000a001976a91495cf859d7a40c5d7fded2a03cb8d7dcf307eab1188ac1976a914a7e2ba4e0d91273d686f446fa04ca5fe800d452d88ac41201f2d052fb372248f89f9f2c9106be9a670d5538c01e4f39215c92717b847d3ea2466e7d1d88010ff98996913ed024dde8ebc860984f7806e5619c88cabf2ef06"
+    Future.successful(Good(tposEncoded))
+  }
+
+  override def getTPoSContractDetails(transactionId: TransactionId): FutureApplicationResult[TPoSContract.Details] = {
+    val contractDetails = randomTPoSContract(txid = transactionId).details
+    Future.successful(Good(contractDetails))
+  }
 }

--- a/server/test/com/xsn/explorer/models/persisted/TransactionSpec.scala
+++ b/server/test/com/xsn/explorer/models/persisted/TransactionSpec.scala
@@ -6,7 +6,6 @@ import com.xsn.explorer.models.rpc.ScriptPubKey
 import com.xsn.explorer.models.values._
 import javax.xml.bind.DatatypeConverter
 import org.scalatest.MustMatchers._
-import org.scalatest.OptionValues._
 import org.scalatest.WordSpec
 
 @com.github.ghik.silencer.silent
@@ -112,7 +111,7 @@ class TransactionSpec extends WordSpec {
       )
 
       val (_, contract) = persisted.Transaction.fromRPC(tx)
-      contract.value must be(expected)
+      contract must be(true)
     }
 
     "accept outputs with empty script" in {

--- a/server/test/com/xsn/explorer/services/TransactionRPCServiceSpec.scala
+++ b/server/test/com/xsn/explorer/services/TransactionRPCServiceSpec.scala
@@ -3,7 +3,7 @@ package com.xsn.explorer.services
 import com.xsn.explorer.errors.{BlockNotFoundError, TransactionError}
 import com.xsn.explorer.helpers.BlockLoader
 import com.xsn.explorer.models.values._
-import com.xsn.explorer.services.validators.TransactionIdValidator
+import com.xsn.explorer.services.validators.{AddressValidator, TransactionIdValidator}
 import org.mockito.MockitoSugar._
 import org.scalactic.{Bad, Good, One}
 import org.scalatest.concurrent.ScalaFutures._
@@ -18,8 +18,10 @@ class TransactionRPCServiceSpec extends AnyWordSpec {
   val transactionIdValidator = mock[TransactionIdValidator]
   val transactionCollectorService = mock[TransactionCollectorService]
   val xsnService = mock[XSNService]
+  val addresValidator = new AddressValidator()
 
-  val service = new TransactionRPCService(transactionIdValidator, transactionCollectorService, xsnService)
+  val service =
+    new TransactionRPCService(transactionIdValidator, transactionCollectorService, xsnService)
 
   "getTransactionLite(height, txindex)" should {
     "get non-cacheable lite transaction" in {

--- a/server/test/controllers/TransactionsControllerSpec.scala
+++ b/server/test/controllers/TransactionsControllerSpec.scala
@@ -44,7 +44,7 @@ class TransactionsControllerSpec extends MyAPISpec {
       sent = 100,
       received = 50,
       height = Height(1)
-    ),
+    )
   )
 
   private val customXSNService = new FileBasedXSNService
@@ -55,11 +55,11 @@ class TransactionsControllerSpec extends MyAPISpec {
     }
 
     override def get(
-      limit: Limit,
-      lastSeenTxid: Option[TransactionId],
-      orderingCondition: OrderingCondition
+        limit: Limit,
+        lastSeenTxid: Option[TransactionId],
+        orderingCondition: OrderingCondition
     ): ApplicationResult[List[TransactionInfo]] = {
-      if(lastSeenTxid == None) {
+      if (lastSeenTxid == None) {
         Good(transactionList)
       } else {
         Good(List(transactionList.last))
@@ -257,7 +257,8 @@ class TransactionsControllerSpec extends MyAPISpec {
     }
 
     "return the transactions with lastSeenTxid" in {
-      val response = GET("/transactions?limit=1&lastSeenTxid=92c51e4fe89466faa734d6207a7ef6115fa1dd33f7156b006fafc6bb85a79eb8")
+      val response =
+        GET("/transactions?limit=1&lastSeenTxid=92c51e4fe89466faa734d6207a7ef6115fa1dd33f7156b006fafc6bb85a79eb8")
 
       status(response) mustEqual OK
       val json = contentAsJson(response)
@@ -325,6 +326,31 @@ class TransactionsControllerSpec extends MyAPISpec {
 
       val cacheHeader = header("Cache-Control", response)
       cacheHeader mustBe None
+    }
+  }
+
+  "POST   /tposcontracts/encode" should {
+    val url = s"/tposcontracts/encode"
+
+    "return the tpos contract encoded" in {
+      val params: String =
+        s"""
+           |{
+           |    "tposAddress" : "XpLy7iJebcUbpmsH1PAiHRn8BrrMdw73KV",
+           |    "merchantAddress" : "XqzYHcK3STW5F22S7kep7dMU4sx3SKFMBv",
+           |    "commission" : 10,
+           |    "signature" : "201F2D052FB372248F89F9F2C9106BE9A670D5538C01E4F39215C92717B847D3EA2466E7D1D88010FF98996913ED024DDE8EBC860984F7806E5619C88CABF2EF06"
+           |}
+           |""".stripMargin
+
+      val response = POST(url, Some(params))
+      status(response) mustEqual OK
+      val json = contentAsJson(response)
+
+      val contract =
+        "020000000a001976a91495cf859d7a40c5d7fded2a03cb8d7dcf307eab1188ac1976a914a7e2ba4e0d91273d686f446fa04ca5fe800d452d88ac41201f2d052fb372248f89f9f2c9106be9a670d5538c01e4f39215c92717b847d3ea2466e7d1d88010ff98996913ed024dde8ebc860984f7806e5619c88cabf2ef06"
+      (json \ "tposContractEncoded").as[String] mustEqual contract
+
     }
   }
 }


### PR DESCRIPTION

- Update blocks synchronizer to identify the new tpos contracts

### Problem

There is a new tpos contract version which is not supported in the block explorer synchronizer. 

### Solution

Update the backend to identify the tpos contracts version 2 
Added an endpoint to get the tpos contract encoded
The route is GET   /tposcontracts