### PR TITLE
server: fix commission percent constraint

### DIFF
--- a/server/conf/evolutions/default/25.sql
+++ b/server/conf/evolutions/default/25.sql
@@ -1,0 +1,9 @@
+# --- !Ups
+
+-- The tpos commission percent changed from 1-99 to 0-100
+ALTER TABLE tpos_contracts DROP CONSTRAINT merchant_commission_percentage;
+ALTER TABLE tpos_contracts ADD CONSTRAINT merchant_commission_percentage CHECK (merchant_commission >= 0 AND merchant_commission <= 100);
+
+# --- !Downs
+ALTER TABLE tpos_contracts DROP CONSTRAINT merchant_commission_percentage;
+ALTER TABLE tpos_contracts ADD CONSTRAINT merchant_commission_percentage CHECK (merchant_commission > 0 AND merchant_commission < 100);


### PR DESCRIPTION
update constraint to accept values from 0 to 100

### Problem

The commission percent constraint rejects the 0 and 100 value
### Solution

fix the constraint to accept values from 0 to 100 
