### PR TITLE
server: fix the getRewardedAddressesCount query

### DIFF
--- a/server/app/com/xsn/explorer/data/anorm/dao/StatisticsPostgresDAO.scala
+++ b/server/app/com/xsn/explorer/data/anorm/dao/StatisticsPostgresDAO.scala
@@ -76,16 +76,16 @@ class StatisticsPostgresDAO {
         |WHERE b.time >= {start_date}
       """.stripMargin
     ).on(
-        'start_date -> startDate.toEpochMilli
-      )
-      .as(SqlParser.scalar[Long].singleOpt)
+      'start_date -> startDate.getEpochSecond
+    ).as(SqlParser.scalar[Long].singleOpt)
       .getOrElse(0)
   }
 }
 
 object StatisticsPostgresDAO {
 
-  /** We need to exclude the burn address from the total supply.
-    */
+  /**
+   * We need to exclude the burn address from the total supply.
+   */
   val BurnAddress = "XmPe9BHRsmZeThtYF34YYjdnrjmcAUn8bC"
 }

--- a/server/test/com/xsn/explorer/data/StatisticsPostgresDataHandlerSpec.scala
+++ b/server/test/com/xsn/explorer/data/StatisticsPostgresDataHandlerSpec.scala
@@ -429,7 +429,7 @@ class StatisticsPostgresDataHandlerSpec extends PostgresDataHandlerSpec with Bef
         nextBlockhash = None,
         height = Height(blockHeight),
         extractionMethod = extractionMethod,
-        time = time.toEpochMilli
+        time = time.getEpochSecond
       )
 
     val tx = randomTransaction(blockhash = block.hash, utxos = List.empty)


### PR DESCRIPTION
the query assumed that blocks time was a milliseconds timestamp but they are in seconds