### PR TITLE
server: add the sum of rewards for the last 72 hours

### DIFF
--- a/server/app/com/xsn/explorer/data/StatisticsDataHandler.scala
+++ b/server/app/com/xsn/explorer/data/StatisticsDataHandler.scala
@@ -1,10 +1,9 @@
 package com.xsn.explorer.data
 
 import java.time.Instant
-
 import com.alexitc.playsonify.core.ApplicationResult
 import com.xsn.explorer.models.values.Address
-import com.xsn.explorer.models.{BlockRewardsSummary, Statistics}
+import com.xsn.explorer.models.{AddressesReward, BlockRewardsSummary, Statistics}
 
 import scala.language.higherKinds
 
@@ -14,7 +13,7 @@ trait StatisticsDataHandler[F[_]] {
 
   def getRewardsSummary(numberOfBlocks: Int): F[BlockRewardsSummary]
 
-  def getRewardedAddressesCount(startDate: Instant): F[Long]
+  def getRewardedAddresses(startDate: Instant): F[AddressesReward]
 
   def getTPoSMerchantStakingAddresses(
       merchantAddress: Address

--- a/server/app/com/xsn/explorer/data/anorm/StatisticsPostgresDataHandler.scala
+++ b/server/app/com/xsn/explorer/data/anorm/StatisticsPostgresDataHandler.scala
@@ -1,12 +1,12 @@
 package com.xsn.explorer.data.anorm
 
 import java.time.Instant
-
 import com.alexitc.playsonify.core.ApplicationResult
 import com.xsn.explorer.data.StatisticsBlockingDataHandler
 import com.xsn.explorer.data.anorm.dao.{StatisticsPostgresDAO, TPoSContractDAO}
 import com.xsn.explorer.models.values.Address
-import com.xsn.explorer.models.{BlockRewardsSummary, Statistics}
+import com.xsn.explorer.models.{AddressesReward, BlockRewardsSummary, Statistics}
+
 import javax.inject.Inject
 import org.scalactic.Good
 import play.api.db.Database
@@ -35,8 +35,8 @@ class StatisticsPostgresDataHandler @Inject() (
     Good(tposContractDAO.getTPoSMerchantStakingAddresses(merchantAddress))
   }
 
-  override def getRewardedAddressesCount(startDate: Instant): ApplicationResult[Long] =
+  override def getRewardedAddresses(startDate: Instant): ApplicationResult[AddressesReward] =
     withConnection { implicit conn =>
-      Good(statisticsDAO.getRewardedAddressesCount(startDate))
+      Good(statisticsDAO.getRewardedAddresses(startDate))
     }
 }

--- a/server/app/com/xsn/explorer/data/anorm/parsers/BlockRewardParsers.scala
+++ b/server/app/com/xsn/explorer/data/anorm/parsers/BlockRewardParsers.scala
@@ -2,11 +2,8 @@ package com.xsn.explorer.data.anorm.parsers
 
 import anorm.SqlParser._
 import anorm._
-import com.xsn.explorer.data.anorm.serializers.BlockRewardPostgresSerializer.{
-  Reward,
-  Stake
-}
-import com.xsn.explorer.models.{BlockReward, BlockRewardsSummary, RewardType}
+import com.xsn.explorer.data.anorm.serializers.BlockRewardPostgresSerializer.{Reward, Stake}
+import com.xsn.explorer.models.{AddressesReward, BlockReward, BlockRewardsSummary, RewardType}
 
 object BlockRewardParsers {
 
@@ -53,4 +50,8 @@ object BlockRewardParsers {
           averageWaitTime
         )
     }
+
+  val addressSummaryParser = (get[Long]("count") ~ get[BigDecimal]("amount")).map { case count ~ amount =>
+    AddressesReward(addressesNumber = count, amount = amount)
+  }
 }

--- a/server/app/com/xsn/explorer/data/async/StatisticsFutureDataHandler.scala
+++ b/server/app/com/xsn/explorer/data/async/StatisticsFutureDataHandler.scala
@@ -1,15 +1,11 @@
 package com.xsn.explorer.data.async
 
 import java.time.Instant
-
 import javax.inject.Inject
 import com.alexitc.playsonify.core.FutureApplicationResult
-import com.xsn.explorer.data.{
-  StatisticsBlockingDataHandler,
-  StatisticsDataHandler
-}
+import com.xsn.explorer.data.{StatisticsBlockingDataHandler, StatisticsDataHandler}
 import com.xsn.explorer.executors.DatabaseExecutionContext
-import com.xsn.explorer.models.{BlockRewardsSummary, Statistics}
+import com.xsn.explorer.models.{AddressesReward, BlockRewardsSummary, Statistics}
 import com.xsn.explorer.models.values.Address
 
 import scala.concurrent.Future
@@ -46,10 +42,10 @@ class StatisticsFutureDataHandler @Inject() (
       }
     }
 
-  override def getRewardedAddressesCount(startDate: Instant): FutureApplicationResult[Long] =
+  override def getRewardedAddresses(startDate: Instant): FutureApplicationResult[AddressesReward] =
     retryableFutureDataHandler.retrying {
       Future {
-        blockingDataHandler.getRewardedAddressesCount(startDate)
+        blockingDataHandler.getRewardedAddresses(startDate)
       }
     }
 }

--- a/server/app/com/xsn/explorer/models/AddressesReward.scala
+++ b/server/app/com/xsn/explorer/models/AddressesReward.scala
@@ -1,0 +1,3 @@
+package com.xsn.explorer.models
+
+case class AddressesReward(addressesNumber: Long, amount: BigDecimal)

--- a/server/app/com/xsn/explorer/services/StatisticsService.scala
+++ b/server/app/com/xsn/explorer/services/StatisticsService.scala
@@ -1,20 +1,26 @@
 package com.xsn.explorer.services
 
 import java.time.Instant
-
 import akka.actor.ActorSystem
 import akka.pattern.ask
 import akka.util.Timeout
 import com.alexitc.playsonify.core.FutureApplicationResult
 import com.alexitc.playsonify.core.FutureOr.Implicits._
-import com.xsn.explorer.data.async.{StatisticsFutureDataHandler, BalanceFutureDataHandler}
-import com.xsn.explorer.models.{MarketStatistics, StatisticsDetails, NodeStatistics, SynchronizationProgress}
+import com.xsn.explorer.data.async.{BalanceFutureDataHandler, StatisticsFutureDataHandler}
+import com.xsn.explorer.models.{
+  AddressesReward,
+  MarketStatistics,
+  NodeStatistics,
+  StatisticsDetails,
+  SynchronizationProgress
+}
 import com.xsn.explorer.tasks.CurrencySynchronizerActor
 import com.xsn.explorer.services.synchronizer.repository.{
   MasternodeRepository,
   MerchantnodeRepository,
   NodeStatsRepository
 }
+
 import javax.inject.Inject
 import org.scalactic.{Bad, Good}
 
@@ -120,10 +126,10 @@ class StatisticsService @Inject() (
       .map(Good(_))
   }
 
-  def getRewardedAddressesCount(period: FiniteDuration): FutureApplicationResult[Long] = {
+  def getRewardedAddresses(period: FiniteDuration): FutureApplicationResult[AddressesReward] = {
     val startDate = Instant.now.minusSeconds(period.toSeconds)
 
-    statisticsFutureDataHandler.getRewardedAddressesCount(startDate)
+    statisticsFutureDataHandler.getRewardedAddresses(startDate)
   }
 
   private def discardErrors[T](

--- a/server/app/controllers/StatisticsController.scala
+++ b/server/app/controllers/StatisticsController.scala
@@ -38,11 +38,14 @@ class StatisticsController @Inject() (
   def getBlockRewardsSummary() = public { _ =>
     val response = for {
       blockRewards <- statisticsService.getRewardsSummary(1000).toFutureOr
-      rewardedAddressesCount <- statisticsService.getRewardedAddressesCount(72.hours).toFutureOr
+      rewardedAddresses <- statisticsService.getRewardedAddresses(72.hours).toFutureOr
 
       rewardsJson = Json.toJson(blockRewards).as[JsObject]
-      result = rewardsJson + ("rewardedAddressesCountLast72Hours" -> Json.toJson(rewardedAddressesCount))
-    } yield Ok(result).withHeaders("Cache-Control" -> "public, max-age=60")
+      result = rewardsJson + ("rewardedAddressesCountLast72Hours" -> Json.toJson(rewardedAddresses.addressesNumber)) +
+        ("rewardedAddressesSumLast72Hours" -> Json.toJson(rewardedAddresses.amount))
+    } yield {
+      Ok(result).withHeaders("Cache-Control" -> "public, max-age=3600")
+    }
 
     response.toFuture
   }

--- a/server/test/com/xsn/explorer/data/StatisticsPostgresDataHandlerSpec.scala
+++ b/server/test/com/xsn/explorer/data/StatisticsPostgresDataHandlerSpec.scala
@@ -1,7 +1,6 @@
 package com.xsn.explorer.data
 
 import java.time.Instant
-
 import com.alexitc.playsonify.sql.FieldOrderingSQLInterpreter
 import com.xsn.explorer.data.anorm.dao.{BalancePostgresDAO, StatisticsPostgresDAO, TPoSContractDAO}
 import com.xsn.explorer.data.anorm.{BalancePostgresDataHandler, StatisticsPostgresDataHandler}
@@ -10,11 +9,19 @@ import com.xsn.explorer.gcs.{GolombCodedSet, UnsignedByte}
 import com.xsn.explorer.helpers.DataGenerator.randomTransaction
 import com.xsn.explorer.helpers.DataHandlerObjects.createLedgerDataHandler
 import com.xsn.explorer.helpers.{BlockLoader, DataGenerator, DataHelper}
-import com.xsn.explorer.models.{BlockExtractionMethod, BlockReward, BlockRewards, PoSBlockRewards, TPoSBlockRewards}
+import com.xsn.explorer.models.{
+  AddressesReward,
+  BlockExtractionMethod,
+  BlockReward,
+  BlockRewards,
+  PoSBlockRewards,
+  TPoSBlockRewards
+}
 import com.xsn.explorer.models.persisted.Balance
 import com.xsn.explorer.models.values.{Address, Height}
 import org.scalactic.Good
 import org.scalatest.BeforeAndAfter
+
 import scala.concurrent.duration._
 
 @com.github.ghik.silencer.silent
@@ -382,18 +389,20 @@ class StatisticsPostgresDataHandlerSpec extends PostgresDataHandlerSpec with Bef
       )
 
       val startDate = Instant.now.minusSeconds(72.hours.toSeconds)
-      dataHandler.getRewardedAddressesCount(startDate) match {
-        case Good(count) =>
-          count mustBe 3
+      val expected = AddressesReward(3, BigDecimal(400))
+      dataHandler.getRewardedAddresses(startDate) match {
+        case Good(result) =>
+          result mustBe expected
         case _ => fail
       }
     }
 
     "return 0 when there are no rewards" in {
       val startDate = Instant.now.minusSeconds(72.hours.toSeconds)
-      dataHandler.getRewardedAddressesCount(startDate) match {
-        case Good(count) =>
-          count mustBe 0
+      val expected = AddressesReward(0, BigDecimal(0))
+      dataHandler.getRewardedAddresses(startDate) match {
+        case Good(result) =>
+          result mustBe expected
         case _ => fail
       }
     }

--- a/server/test/controllers/StatisticsControllerSpec.scala
+++ b/server/test/controllers/StatisticsControllerSpec.scala
@@ -1,12 +1,18 @@
 package controllers
 
 import java.time.Instant
-
 import akka.actor.{Actor, ActorSystem, Props}
 import com.alexitc.playsonify.core.ApplicationResult
 import com.xsn.explorer.data.StatisticsBlockingDataHandler
 import com.xsn.explorer.errors.XSNUnexpectedResponseError
-import com.xsn.explorer.models.{BlockRewardsSummary, MarketInformation, MarketStatistics, Statistics, NodeStatistics}
+import com.xsn.explorer.models.{
+  AddressesReward,
+  BlockRewardsSummary,
+  MarketInformation,
+  MarketStatistics,
+  NodeStatistics,
+  Statistics
+}
 import com.xsn.explorer.services.{Currency, XSNService}
 import com.xsn.explorer.tasks.CurrencySynchronizerActor
 import com.xsn.explorer.services.synchronizer.repository.{
@@ -69,7 +75,9 @@ class StatisticsControllerSpec extends MyAPISpec with BeforeAndAfterAll {
         address: Address
     ): ApplicationResult[List[Address]] = Good(List(Address.from("123").get))
 
-    override def getRewardedAddressesCount(startDate: Instant): ApplicationResult[Long] = Good(123L)
+    override def getRewardedAddresses(startDate: Instant): ApplicationResult[AddressesReward] = Good(
+      AddressesReward(123L, BigDecimal(1000.0))
+    )
   }
 
   val xsnService = mock[XSNService]
@@ -223,6 +231,8 @@ class StatisticsControllerSpec extends MyAPISpec with BeforeAndAfterAll {
         "70000.12345678"
       )
       (json \ "rewardedAddressesCountLast72Hours").as[BigDecimal] mustEqual 123L
+
+      (json \ "rewardedAddressesSumLast72Hours").as[BigDecimal] mustEqual BigDecimal(1000)
     }
   }
 


### PR DESCRIPTION
### Problem

The `rewards-summary` endpoint doesn't return the rewards amount from the last 72 hours 

### Solution

Add the rewards amount of the for the last 72 hours to the `rewards-summary` endpoint 