### PR TITLE
server: Add the enabled masternodes to the /stats endpoint

### DIFF
--- a/server/app/com/xsn/explorer/models/ROI.scala
+++ b/server/app/com/xsn/explorer/models/ROI.scala
@@ -1,0 +1,3 @@
+package com.xsn.explorer.models
+
+case class ROI(masternodes: BigDecimal, staking: BigDecimal)

--- a/server/app/com/xsn/explorer/models/StatisticsDetails.scala
+++ b/server/app/com/xsn/explorer/models/StatisticsDetails.scala
@@ -6,7 +6,8 @@ case class StatisticsDetails(
     statistics: Statistics,
     masternodes: Option[Int],
     tposnodes: Option[Int],
-    difficulty: Option[BigDecimal]
+    difficulty: Option[BigDecimal],
+    masternodes_enabled: Option[Int]
 )
 
 object StatisticsDetails {
@@ -25,7 +26,8 @@ object StatisticsDetails {
       ),
       "masternodes" -> obj.masternodes.map(c => JsNumber.apply(c)),
       "tposnodes" -> obj.tposnodes.map(c => JsNumber.apply(c)),
-      "difficulty" -> obj.difficulty.map(c => JsNumber.apply(c))
+      "difficulty" -> obj.difficulty.map(c => JsNumber.apply(c)),
+      "masternodes_enabled" -> obj.masternodes_enabled.map(c => JsNumber.apply(c))
     ).flatMap { case (key, maybe) =>
       maybe.map(key -> _)
     }

--- a/server/app/controllers/StatisticsController.scala
+++ b/server/app/controllers/StatisticsController.scala
@@ -39,11 +39,17 @@ class StatisticsController @Inject() (
     val response = for {
       blockRewards <- statisticsService.getRewardsSummary(1000).toFutureOr
       rewardedAddresses <- statisticsService.getRewardedAddresses(72.hours).toFutureOr
+      roi <- statisticsService.getROI(rewardedAddresses.amount).toFutureOr
 
-      rewardsJson = Json.toJson(blockRewards).as[JsObject]
-      result = rewardsJson + ("rewardedAddressesCountLast72Hours" -> Json.toJson(rewardedAddresses.addressesNumber)) +
-        ("rewardedAddressesSumLast72Hours" -> Json.toJson(rewardedAddresses.amount))
     } yield {
+
+      val rewardsJson = Json.toJson(blockRewards).as[JsObject]
+      val result = rewardsJson +
+        ("rewardedAddressesCountLast72Hours" -> Json.toJson(rewardedAddresses.addressesNumber)) +
+        ("rewardedAddressesSumLast72Hours" -> Json.toJson(rewardedAddresses.amount)) +
+        ("masternodesROI" -> Json.toJson(roi.masternodes)) +
+        ("stakingROI" -> Json.toJson(roi.staking))
+
       Ok(result).withHeaders("Cache-Control" -> "public, max-age=3600")
     }
 

--- a/server/test/controllers/StatisticsControllerSpec.scala
+++ b/server/test/controllers/StatisticsControllerSpec.scala
@@ -113,9 +113,13 @@ class StatisticsControllerSpec extends MyAPISpec with BeforeAndAfterAll {
     "return the server statistics" in {
       val masternodes = 1000
       val tposnodes = 100
+      val enabledMasternodes = 200
+
       val difficulty = BigDecimal("129.1827211827212")
       when(masternodeRepository.getCount())
         .thenReturn(Future.successful(masternodes))
+      when(masternodeRepository.getEnabledCount())
+        .thenReturn(Future.successful(enabledMasternodes))
       when(masternodeRepository.getAll()).thenReturn(Future.successful(List()))
       when(merchantnodeRepository.getCount())
         .thenReturn(Future.successful(tposnodes))
@@ -136,13 +140,18 @@ class StatisticsControllerSpec extends MyAPISpec with BeforeAndAfterAll {
       (json \ "masternodes").as[Int] mustEqual masternodes
       (json \ "tposnodes").as[Int] mustEqual tposnodes
       (json \ "difficulty").as[BigDecimal] mustEqual difficulty
+      (json \ "masternodes_enabled").as[Int] mustEqual enabledMasternodes
+
     }
 
     "return the stats even if getting the difficulty throws an exception" in {
       val masternodes = 1000
+      val enabledMasternodes = 200
       val tposnodes = 100
       when(masternodeRepository.getCount())
         .thenReturn(Future.successful(masternodes))
+      when(masternodeRepository.getEnabledCount())
+        .thenReturn(Future.successful(enabledMasternodes))
       when(merchantnodeRepository.getCount())
         .thenReturn(Future.successful(tposnodes))
       when(xsnService.getDifficulty()).thenReturn(Future.failed(new Exception))
@@ -205,34 +214,26 @@ class StatisticsControllerSpec extends MyAPISpec with BeforeAndAfterAll {
 
   "GET /rewards-summary" should {
     "get rewards summary" in {
+
+      val enabledMasternodes = 40
+      when(masternodeRepository.getEnabledCount())
+        .thenReturn(Future.successful(enabledMasternodes))
+
       val response = GET(s"/rewards-summary")
       status(response) mustEqual OK
 
       val json = contentAsJson(response)
-      (json \ "averageReward").as[BigDecimal] mustEqual BigDecimal(
-        "1000.12345678"
-      )
-      (json \ "averageInput").as[BigDecimal] mustEqual BigDecimal(
-        "4800.12345678"
-      )
-      (json \ "medianInput").as[BigDecimal] mustEqual BigDecimal(
-        "4900.12345678"
-      )
-      (json \ "averagePoSInput").as[BigDecimal] mustEqual BigDecimal(
-        "5000.12345678"
-      )
-      (json \ "averageTPoSInput").as[BigDecimal] mustEqual BigDecimal(
-        "4500.12345678"
-      )
-      (json \ "medianWaitTime").as[BigDecimal] mustEqual BigDecimal(
-        "60000.12345678"
-      )
-      (json \ "averageWaitTime").as[BigDecimal] mustEqual BigDecimal(
-        "70000.12345678"
-      )
+      (json \ "averageReward").as[BigDecimal] mustEqual BigDecimal("1000.12345678")
+      (json \ "averageInput").as[BigDecimal] mustEqual BigDecimal("4800.12345678")
+      (json \ "medianInput").as[BigDecimal] mustEqual BigDecimal("4900.12345678")
+      (json \ "averagePoSInput").as[BigDecimal] mustEqual BigDecimal("5000.12345678")
+      (json \ "averageTPoSInput").as[BigDecimal] mustEqual BigDecimal("4500.12345678")
+      (json \ "medianWaitTime").as[BigDecimal] mustEqual BigDecimal("60000.12345678")
+      (json \ "averageWaitTime").as[BigDecimal] mustEqual BigDecimal("70000.12345678")
       (json \ "rewardedAddressesCountLast72Hours").as[BigDecimal] mustEqual 123L
-
       (json \ "rewardedAddressesSumLast72Hours").as[BigDecimal] mustEqual BigDecimal(1000)
+      (json \ "masternodesROI").as[BigDecimal] mustEqual BigDecimal(7.884)
+      (json \ "stakingROI").as[BigDecimal] mustEqual BigDecimal(4730.4)
     }
   }
 


### PR DESCRIPTION

### Problem
There isn't any ROI calculation in the `rewards-summary` endpoint 

### Solution

Add the ROI calculation  of the masternodes and the staking to the `/rewards-summary` endpoint

