### PR TITLE
server: remove transactions sent/received migration

### DIFF
--- a/server/app/com/xsn/explorer/data/anorm/dao/TransactionPostgresDAO.scala
+++ b/server/app/com/xsn/explorer/data/anorm/dao/TransactionPostgresDAO.scala
@@ -438,9 +438,7 @@ class TransactionPostgresDAO @Inject() (
         |   ORDER BY time $order, txid
         |   LIMIT {limit}
         |)
-        |SELECT t.txid, t.blockhash, t.time, t.size, blk.height,
-        |       COALESCE(t.sent, (SELECT COALESCE(SUM(value), 0) FROM transaction_inputs WHERE txid = t.txid)) as sent,
-        |       COALESCE(t.received, (SELECT COALESCE(SUM(value), 0) FROM transaction_outputs WHERE txid = t.txid)) as received
+        |SELECT t.txid, t.blockhash, t.time, t.size, blk.height, t.sent, t.received
         |FROM TXS t JOIN blocks blk USING (blockhash)
       """.stripMargin
     ).on(
@@ -486,9 +484,7 @@ class TransactionPostgresDAO @Inject() (
         |  ORDER BY time $order, txid
         |  LIMIT {limit}
         |)
-        |SELECT t.txid, t.blockhash, t.time, t.size, blk.height,
-        |       COALESCE(t.sent, (SELECT COALESCE(SUM(value), 0) FROM transaction_inputs WHERE txid = t.txid)) as sent,
-        |       COALESCE(t.received, (SELECT COALESCE(SUM(value), 0) FROM transaction_outputs WHERE txid = t.txid)) as received
+        |SELECT t.txid, t.blockhash, t.time, t.size, blk.height, t.sent, t.received
         |FROM TXS t JOIN blocks blk USING (blockhash)
       """.stripMargin
     ).on(

--- a/server/conf/evolutions/default/27.sql
+++ b/server/conf/evolutions/default/27.sql
@@ -1,0 +1,4 @@
+# --- !Ups
+
+ALTER TABLE transactions ALTER COLUMN sent SET NOT NULL;
+ALTER TABLE transactions ALTER COLUMN received SET NOT NULL;

--- a/server/test/com/xsn/explorer/data/TransactionPostgresDataHandlerSpec.scala
+++ b/server/test/com/xsn/explorer/data/TransactionPostgresDataHandlerSpec.scala
@@ -451,31 +451,6 @@ class TransactionPostgresDataHandlerSpec extends PostgresDataHandlerSpec with Be
       result(1).blockhash mustEqual sorted(1).blockhash
     }
 
-    "return sent and received amount even when they are null on transactions table without last seen tx" in {
-      prepare()
-
-      database.withConnection { implicit connection =>
-        SQL(
-          s"""
-             |UPDATE transactions
-             |SET sent = null, received = null
-      """.stripMargin
-        ).execute
-      }
-
-      val result = dataHandler.get(Limit(2), None, OrderingCondition.DescendingOrder, true).get
-
-      result.head.id mustEqual dummyTransaction.id
-      result.head.blockhash mustEqual dummyTransaction.blockhash
-      result.head.received mustEqual dummyTransaction.received
-      result.head.sent mustEqual dummyTransaction.sent
-
-      result(1).id mustEqual sorted.head.id
-      result(1).blockhash mustEqual sorted.head.blockhash
-      result(1).received mustEqual sorted.head.received
-      result(1).sent mustEqual sorted.head.sent
-    }
-
     "return the next elements given the last seen tx" in {
       prepare()
 
@@ -498,29 +473,6 @@ class TransactionPostgresDataHandlerSpec extends PostgresDataHandlerSpec with Be
 
       result.head.id mustEqual expected.id
       result.head.blockhash mustEqual expected.blockhash
-    }
-
-    "return sent and received amount even when they are null on transactions table given the last seen tx" in {
-      prepare()
-
-      database.withConnection { implicit connection =>
-        SQL(
-          s"""
-             |UPDATE transactions
-             |SET sent = null, received = null
-      """.stripMargin
-        ).execute
-      }
-
-      val lastSeenTxid = dummyTransaction.id
-      val expected = sorted.head
-
-      val result = dataHandler.get(Limit(1), Option(lastSeenTxid), OrderingCondition.DescendingOrder, true).get
-
-      result.head.id mustEqual expected.id
-      result.head.blockhash mustEqual expected.blockhash
-      result.head.received mustEqual expected.received
-      result.head.sent mustEqual expected.sent
     }
 
     "return no elements on unknown lastSeenTransaction" in {


### PR DESCRIPTION
sent and received columns on the transactions table are set to NOT NULL since the migration is done so there are no more nulls on the table and the fallback calculation on some queries was removed