### PR TITLE
filter transaction inputs that have value of 0

### DIFF
--- a/server/app/com/xsn/explorer/models/persisted/Transaction.scala
+++ b/server/app/com/xsn/explorer/models/persisted/Transaction.scala
@@ -103,6 +103,7 @@ object Transaction {
           vin.addresses
         )
       }
+      .filter(_.value > 0)
 
     val outputs = tx.vout.flatMap { vout =>
       for {


### PR DESCRIPTION
transaction outputs of value 0 are not stored in the database so inputs that spend those outputs should be ignored too to avoid problems with foreign key in the transaction_inputs table that points to the spent output