### PR TITLE
Replaced scalafmtCheck for scalafmtCheckAll

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -21,7 +21,7 @@ jobs:
         uses: japgolly/setup-everything-scala@v1.0
 
       - name: Check code format
-        run: cd server && sbt scalafmtCheck
+        run: cd server && sbt scalafmtCheckAll
 
       - name: Compile
         run: cd server && sbt compile


### PR DESCRIPTION
### Problem

For some reason scalafmtCheck doesn't check test folders. In contrast, scalafmtCheckAll is supposed to. 

> scalafmtAll or scalafmtCheckAll: Execute the scalafmt or scalafmtCheck task for all configurations in which it is enabled

Source: https://scalameta.org/scalafmt/docs/installation.html#sbt

### Solution

I replaced scalafmtCheck for scalafmtCheckAll in CI github workflow.