### PR TITLE
server: Add currencies mentioned in issue #117 for the stakenet-light-wallet

### DIFF
--- a/server/app/com/xsn/explorer/services/CurrencyService.scala
+++ b/server/app/com/xsn/explorer/services/CurrencyService.scala
@@ -29,6 +29,13 @@ object Currency extends Enum[Currency] {
   final case object NZD extends Currency("NZD")
   final case object TRY extends Currency("TRY")
   final case object UAH extends Currency("UAH")
+  final case object UAH extends Currency("AUD")
+  final case object UAH extends Currency("CNY")
+  final case object UAH extends Currency("CHF")
+  final case object UAH extends Currency("RUB")
+  final case object UAH extends Currency("NOK")
+  final case object UAH extends Currency("WON")
+  final case object UAH extends Currency("BRL")
 
   val values = findValues
 }

--- a/server/app/com/xsn/explorer/services/CurrencyService.scala
+++ b/server/app/com/xsn/explorer/services/CurrencyService.scala
@@ -29,13 +29,13 @@ object Currency extends Enum[Currency] {
   final case object NZD extends Currency("NZD")
   final case object TRY extends Currency("TRY")
   final case object UAH extends Currency("UAH")
-  final case object UAH extends Currency("AUD")
-  final case object UAH extends Currency("CNY")
-  final case object UAH extends Currency("CHF")
-  final case object UAH extends Currency("RUB")
-  final case object UAH extends Currency("NOK")
-  final case object UAH extends Currency("WON")
-  final case object UAH extends Currency("BRL")
+  final case object AUD extends Currency("AUD")
+  final case object CNY extends Currency("CNY")
+  final case object CHF extends Currency("CHF")
+  final case object RUB extends Currency("RUB")
+  final case object NOK extends Currency("NOK")
+  final case object WON extends Currency("WON")
+  final case object BRL extends Currency("BRL")
 
   val values = findValues
 }


### PR DESCRIPTION
### Problem
For the feature #117 (trello ref), we would like to add more currencies. Since the dex use the block explorer to get the currency rates, we have to add these currencies in the block explorer repo first.
![image](https://user-images.githubusercontent.com/95255488/151449606-e263e2d5-9f16-4446-ac03-021e98b05307.png)

**NB: This is not an urgent feature**

### Solution

After looking around in the project, i realized that by just adding a new line to the object Currency extends Enum[Currency] with the correct(recognized) currency code provided by CMC, it will make the conversion rates works.

Also seeing this api endpoint format, it kindly confirm the process to works and it shouldn't impact too much the current application state.

_getPrice in CurrencyService.scala_
`s"v1/tools/price-conversion?id=${coinMarketCapConfig.coinID.string}&amount=1&convert=${currency.entryName}"`

### Result

I've aswell had a discussion with @AlexITC regarding the implementation, as he told me, he has to verify the current CMC API plan in place to see if adding more currencies won't overwhelm your calls quotas.

I've made some tests with the api payload to make sure the currencies were correct:
```
BTC examples conversions CMC:

USD
"data": {
    "id": 1,
    "symbol": "BTC",
    "name": "Bitcoin",
    "amount": 1,
    "last_updated": "2022-01-27T20:54:00.000Z",
    "quote": {
        "USD": {
            "price": 35918.82342837237,
            "last_updated": "2022-01-27T20:54:00.000Z"
        }
    }
}

AUD
"data": {
    "id": 1,
    "symbol": "BTC",
    "name": "Bitcoin",
    "amount": 1,
    "last_updated": "2022-01-27T20:55:00.000Z",
    "quote": {
        "AUD": {
            "price": 51067.0957600385,
            "last_updated": "2022-01-27T20:55:02.000Z"
        }
    }
}

CHF
"data": {
    "id": 1,
    "symbol": "BTC",
    "name": "Bitcoin",
    "amount": 1,
    "last_updated": "2022-01-27T20:54:00.000Z",
    "quote": {
        "CHF": {
            "price": 33445.309571801066,
            "last_updated": "2022-01-27T20:54:02.000Z"
        }
    }
}

CNY
"data": {
    "id": 1,
    "symbol": "BTC",
    "name": "Bitcoin",
    "amount": 1,
    "last_updated": "2022-01-27T20:57:00.000Z",
    "quote": {
        "CNY": {
            "price": 228436.46126972494,
            "last_updated": "2022-01-27T20:57:02.000Z"
        }
    }
}

RUB
"data": {
    "id": 1,
    "symbol": "BTC",
    "name": "Bitcoin",
    "amount": 1,
    "last_updated": "2022-01-27T20:58:00.000Z",
    "quote": {
        "RUB": {
            "price": 2795248.838970382,
            "last_updated": "2022-01-27T20:58:03.000Z"
        }
    }
}

NOK
"data": {
    "id": 1,
    "symbol": "BTC",
    "name": "Bitcoin",
    "amount": 1,
    "last_updated": "2022-01-27T20:58:00.000Z",
    "quote": {
        "NOK": {
            "price": 320860.58436084737,
            "last_updated": "2022-01-27T20:58:03.000Z"
        }
    }
}

WON
"data": {
    "id": 1,
    "symbol": "BTC",
    "name": "Bitcoin",
    "amount": 1,
    "last_updated": "2022-01-27T21:28:00.000Z",
    "quote": {
        "WON": {
            "price": 4710206.354904945,
            "last_updated": "2022-01-27T21:27:00.000Z"
        }
    }
}

BRL
"data": {
    "id": 1,
    "symbol": "BTC",
    "name": "Bitcoin",
    "amount": 1,
    "last_updated": "2022-01-27T21:28:00.000Z",
    "quote": {
        "BRL": {
            "price": 193458.57072520445,
            "last_updated": "2022-01-27T21:28:03.000Z"
        }
    }
}
```