### PR TITLE
Fix transaction parsing for bitcoin core 23

### DIFF
--- a/server/app/com/xsn/explorer/models/rpc/ScriptPubKey.scala
+++ b/server/app/com/xsn/explorer/models/rpc/ScriptPubKey.scala
@@ -25,12 +25,13 @@ object ScriptPubKey {
     val builder = (__ \ "type").read[String] and
       (__ \ "asm").read[String] and
       (__ \ "hex").read[String].map(HexString.from) and
-      (__ \ "addresses").readNullable[List[Address]].map(_ getOrElse List.empty)
+      (__ \ "addresses").readNullable[List[Address]] and
+      (__ \ "address").readNullable[Address].map(_.map(a => List(a)))
 
-    builder.apply { (t, asm, hexString, addresses) =>
+    builder.apply { (t, asm, hexString, addresses, address) =>
       for {
         hex <- hexString
-      } yield ScriptPubKey(t, asm = asm, hex = hex, addresses = addresses)
+      } yield ScriptPubKey(t, asm = asm, hex = hex, addresses = addresses.orElse(address).getOrElse(List.empty))
     }
   }
 }

--- a/server/test/controllers/TransactionsControllerSpec.scala
+++ b/server/test/controllers/TransactionsControllerSpec.scala
@@ -294,6 +294,22 @@ class TransactionsControllerSpec extends MyAPISpec {
       (error \ "field").as[String] mustEqual "transactionId"
       (error \ "message").as[String].nonEmpty mustEqual true
     }
+
+    "work with transactions from bitcoin core 23" in {
+      val tx = TransactionLoader.get("f69b3b50639df7bfda7897e978d8d6d7047aa97cb929163cdbe105acd005a1aa")
+
+      val response = GET(url(tx.id.string))
+
+      status(response) mustEqual OK
+      val json = contentAsJson(response)
+
+      val inputs = (json \ "input").as[List[JsValue]]
+      val outputs = (json \ "output").as[List[JsValue]]
+
+      (inputs.head \ "address").asOpt[String] mustBe Some("tb1qsexpvl92hmfh66c38dkx35rycfjakcfhy0892x")
+      (outputs.head \ "address").asOpt[String] mustBe Some("tb1qdhznp5jxyw9ypew0npl9sqc2za2ryf9zykwxh3")
+      (outputs(1) \ "address").asOpt[String] mustBe Some("tb1qzfevzferqdydtjca9k3n0dqp48ks0pz90629uq")
+    }
   }
 
   "GET transactions/:txid/raw" should {

--- a/server/test/resources/transactions/xsn/5789a36b0d64cdbfd45f52d36d26e803f38230f38abaa354df6c900441dcedac
+++ b/server/test/resources/transactions/xsn/5789a36b0d64cdbfd45f52d36d26e803f38230f38abaa354df6c900441dcedac
@@ -1,0 +1,53 @@
+{
+    "txid": "5789a36b0d64cdbfd45f52d36d26e803f38230f38abaa354df6c900441dcedac",
+    "hash": "13c7d8fa4f1009191039aee9b2f157d8209c0ae2f3a821a2976a1ab4c7feb7d2",
+    "version": 2,
+    "size": 222,
+    "vsize": 141,
+    "weight": 561,
+    "locktime": 2408829,
+    "vin": [
+        {
+            "txid": "ff82c8c789eee96f67d09db48b5018000df9576830c10a25b72412efd81c6267",
+            "vout": 0,
+            "scriptSig": {
+                "asm": "",
+                "hex": ""
+            },
+            "txinwitness": [
+                "304402203c5d8b741e00c8c05f43dbf984b7511a35959c5aa5b2ff618c87e376c614180b022022c0a0e913539262df092953daf6efe7a095a34aa34e74070ca9aee037c47a9701",
+                "03a8b733ecbe91e5313df7a57d665cf64c4587abab3be43ab944a69ffc2df2121b"
+            ],
+            "sequence": 4294967294
+        }
+    ],
+    "vout": [
+        {
+            "value": 0.00006,
+            "n": 0,
+            "scriptPubKey": {
+                "asm": "0 880f255bb2a58910fcbe6e605a8de01d34e7a3b1",
+                "desc": "addr(tb1q3q8j2kaj5ky3pl97des94r0qr56w0ga3fddqg9)#vqn36tkd",
+                "hex": "0014880f255bb2a58910fcbe6e605a8de01d34e7a3b1",
+                "address": "tb1q3q8j2kaj5ky3pl97des94r0qr56w0ga3fddqg9",
+                "type": "witness_v0_keyhash"
+            }
+        },
+        {
+            "value": 0.01149626,
+            "n": 1,
+            "scriptPubKey": {
+                "asm": "0 864c167caabed37d6b113b6c68d064c265db6137",
+                "desc": "addr(tb1qsexpvl92hmfh66c38dkx35rycfjakcfhy0892x)#4cq3pmjt",
+                "hex": "0014864c167caabed37d6b113b6c68d064c265db6137",
+                "address": "tb1qsexpvl92hmfh66c38dkx35rycfjakcfhy0892x",
+                "type": "witness_v0_keyhash"
+            }
+        }
+    ],
+    "hex": "0200000000010167621cd8ef1224b7250ac1306857f90d0018508bb49dd0676fe9ee89c7c882ff0000000000feffffff027017000000000000160014880f255bb2a58910fcbe6e605a8de01d34e7a3b1ba8a110000000000160014864c167caabed37d6b113b6c68d064c265db61370247304402203c5d8b741e00c8c05f43dbf984b7511a35959c5aa5b2ff618c87e376c614180b022022c0a0e913539262df092953daf6efe7a095a34aa34e74070ca9aee037c47a97012103a8b733ecbe91e5313df7a57d665cf64c4587abab3be43ab944a69ffc2df2121b7dc12400",
+    "blockhash": "00000000000000362c340c56cba7a0dee144d84b8c4b76b53f0893df55a6b06f",
+    "confirmations": 36,
+    "time": 1669652275,
+    "blocktime": 1669652275
+}

--- a/server/test/resources/transactions/xsn/f69b3b50639df7bfda7897e978d8d6d7047aa97cb929163cdbe105acd005a1aa
+++ b/server/test/resources/transactions/xsn/f69b3b50639df7bfda7897e978d8d6d7047aa97cb929163cdbe105acd005a1aa
@@ -1,0 +1,53 @@
+{
+    "txid": "f69b3b50639df7bfda7897e978d8d6d7047aa97cb929163cdbe105acd005a1aa",
+    "hash": "ff9d38736c87f5869d17e9885019690e6fbc6c0131e8fe9a495b4fc713aed1f6",
+    "version": 2,
+    "size": 222,
+    "vsize": 141,
+    "weight": 561,
+    "locktime": 2408831,
+    "vin": [
+        {
+            "txid": "5789a36b0d64cdbfd45f52d36d26e803f38230f38abaa354df6c900441dcedac",
+            "vout": 1,
+            "scriptSig": {
+                "asm": "",
+                "hex": ""
+            },
+            "txinwitness": [
+                "304402204447bb2a40ae93603c90e435d173d36aab6492122da65051e4385cd71f179d56022072df47e282b427a9f3f1940f7750eacccaa07bbcf2b43c2262590e6333c0fee601",
+                "021303d40b11ef1d9da320097e670e0e360a913f1a793ab2004015d0360a34c26b"
+            ],
+            "sequence": 4294967294
+        }
+    ],
+    "vout": [
+        {
+            "value": 0.01148485,
+            "n": 0,
+            "scriptPubKey": {
+                "asm": "0 6dc530d246238a40e5cf987e58030a17543224a2",
+                "desc": "addr(tb1qdhznp5jxyw9ypew0npl9sqc2za2ryf9zykwxh3)#x6gf6f36",
+                "hex": "00146dc530d246238a40e5cf987e58030a17543224a2",
+                "address": "tb1qdhznp5jxyw9ypew0npl9sqc2za2ryf9zykwxh3",
+                "type": "witness_v0_keyhash"
+            }
+        },
+        {
+            "value": 0.00001,
+            "n": 1,
+            "scriptPubKey": {
+                "asm": "0 1272c127230348d5cb1d2da337b401a9ed078445",
+                "desc": "addr(tb1qzfevzferqdydtjca9k3n0dqp48ks0pz90629uq)#fj683nxx",
+                "hex": "00141272c127230348d5cb1d2da337b401a9ed078445",
+                "address": "tb1qzfevzferqdydtjca9k3n0dqp48ks0pz90629uq",
+                "type": "witness_v0_keyhash"
+            }
+        }
+    ],
+    "hex": "02000000000101aceddc4104906cdf54a3ba8af33082f303e8266dd3525fd4bfcd640d6ba389570100000000feffffff0245861100000000001600146dc530d246238a40e5cf987e58030a17543224a2e8030000000000001600141272c127230348d5cb1d2da337b401a9ed0784450247304402204447bb2a40ae93603c90e435d173d36aab6492122da65051e4385cd71f179d56022072df47e282b427a9f3f1940f7750eacccaa07bbcf2b43c2262590e6333c0fee60121021303d40b11ef1d9da320097e670e0e360a913f1a793ab2004015d0360a34c26b7fc12400",
+    "blockhash": "000000000000001399f90d5211a445c3c618c9b5eae04fea39ca457bcc638215",
+    "confirmations": 29,
+    "time": 1669652980,
+    "blocktime": 1669652980
+}


### PR DESCRIPTION
From the bitcoin core 23 release notes (https://bitcoincore.org/en/releases/23.0/):

  The -deprecatedrpc=addresses configuration option has been removed.
  RPCs gettxout, getrawtransaction, decoderawtransaction, decodescript, gettransaction verbose=true
  and REST endpoints /rest/tx, /rest/getutxos, /rest/block no longer return the addresses and reqSigs fields,
  which were previously deprecated in 22.0. (#22650)

Now we will fallback to "address" if "addresses" is missing when parsing a transaction